### PR TITLE
Fix InventoryItems::get promise

### DIFF
--- a/services/inventory_items.ts
+++ b/services/inventory_items.ts
@@ -16,7 +16,7 @@ export class InventoryItems extends BaseService {
      * @param options Options for filtering the result.
      */
     public get(id: number, options?: Options.FieldOptions) {
-        return this.createRequest<Location>("GET", `${id}.json`, "inventory_item", options);
+        return this.createRequest<InventoryItem>("GET", `${id}.json`, "inventory_item", options);
     }
 
     /**


### PR DESCRIPTION
When building a project using this library, I got the following error 
```
node_modules/shopify-prime/dist/services/inventory_items.d.ts(14,62): error TS2304: Cannot find name 'Location'.
```

The `InventoryItems::get` method types against a `Location` object, instead of an `InventoryItem`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nozzlegear/shopify-prime/34)
<!-- Reviewable:end -->
